### PR TITLE
Restore compression operation by filtering the target textures

### DIFF
--- a/src/optimizeCmd.ts
+++ b/src/optimizeCmd.ts
@@ -148,18 +148,19 @@ async function optimizeFile(inputFile: string, outputFile: string, { logger, tex
   const doc = io.read(inputFile);
 
   const compressTextures =
-    texCompressionMode === null ? () => {} : toktx({ mode: texCompressionMode, powerOfTwo: true });
+    texCompressionMode === null ? () => {} : toktx({ mode: texCompressionMode, powerOfTwo: true, slots: '{baseColorTexture,emissiveTexture,metallicRoughnessTexture,normalTexture}' });
 
   doc.setLogger(logger);
 
-  // await doc.transform(
-  // fixTextureMimetypes()
-  // printTextureMem("Uncompressed"),
-  // compressTextures,
-  // dedup({ textures: false, accessors: true }),
-  // weld(),
-  // printTextureMem("Compressed")
-  // );
+  
+  await doc.transform(
+    fixTextureMimetypes(),
+    printTextureMem("Uncompressed"),
+    compressTextures,
+    // dedup({ textures: false, accessors: true }),
+    // weld(),
+    printTextureMem("Compressed")
+  );
 
   io.write(outputFile, doc);
 


### PR DESCRIPTION
Potential temporary fix for the compression step by only targeting PBR texture slots and ignoring the lightmap and environment textures, which could be HDR format and hence will not compress.

I would rather it do it with something like this [upstream PR](https://github.com/donmccurdy/glTF-Transform/pull/369) because it covers the situation where the extension textures are actually PNG or JPEG. This change allows compression to proceed at least.