### PR TITLE
Added "auto" and "none" to compression options

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -11,8 +11,8 @@ program
   .argument("<output>", "output gltf/glb file")
   .option(
     "--ktx <compression-format>",
-    "Compress textures into KTX2 + Basis textures with the specified compression format",
-    { validator: ["etc1s", "uastc"] }
+    "Compress textures into KTX2 + Basis with either the specified format, 'none' to prevent compression, or 'auto' to select an appropriate format for the texture type (default)",
+    { validator: ["auto", "etc1s", "uastc", "none"], default: "auto" }
   )
   .option("--serve", "serve up the optimized file via an internal webserver on the specified port after optimizing")
   .option("--serve-port <port>", "Port to use for the internal webserver", { default: 7777 })


### PR DESCRIPTION
Following [a Discord discussion](https://discord.com/channels/498741086295031808/945782481423052800) the following changes are proposed in this PR:

1. Make texture compression the default behaviour even if no command line option is set. This tool doesn't do anything except compress textures currently, but even if it did I think this behaviour is appropriate.
2. Select the compression format based on texture use type, which means UASTC for normal maps and ETC1S for everything else. This corresponds to the default _auto_ mode, but it can be overridden by the existing _etc1s_ and _uastc_ modes.