### PR TITLE
Add basic support for Draco mesh compression.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "@gltf-transform/functions": "^0.12.7",
         "connect-static-file": "^2.0.0",
         "cors": "^2.8.5",
+        "draco3dgltf": "^1.5.2",
         "express": "^4.17.1",
         "https": "^1.0.0",
         "selfsigned": "^1.10.8",
@@ -4277,9 +4278,9 @@
       }
     },
     "node_modules/draco3dgltf": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/draco3dgltf/-/draco3dgltf-1.4.1.tgz",
-      "integrity": "sha512-/d3SSWca9ftcNkpSOG6dwm3z7iQtM2oqnD6Eiy4YwJczbcQ3jEkDYrtBl8RuvS9xPKqwpsyciQejAtddyjKvFg=="
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/draco3dgltf/-/draco3dgltf-1.5.2.tgz",
+      "integrity": "sha512-lw3oa87pN6iBqwibLvtXp4uHczK/mXqacjVaORJhAze7mgd0lgw1XXf4I1KtaU/W/O+6zdDrPLx8VZz86aXbqA=="
     },
     "node_modules/duplexer": {
       "version": "0.1.1",
@@ -16022,9 +16023,9 @@
       }
     },
     "draco3dgltf": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/draco3dgltf/-/draco3dgltf-1.4.1.tgz",
-      "integrity": "sha512-/d3SSWca9ftcNkpSOG6dwm3z7iQtM2oqnD6Eiy4YwJczbcQ3jEkDYrtBl8RuvS9xPKqwpsyciQejAtddyjKvFg=="
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/draco3dgltf/-/draco3dgltf-1.5.2.tgz",
+      "integrity": "sha512-lw3oa87pN6iBqwibLvtXp4uHczK/mXqacjVaORJhAze7mgd0lgw1XXf4I1KtaU/W/O+6zdDrPLx8VZz86aXbqA=="
     },
     "duplexer": {
       "version": "0.1.1",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "@gltf-transform/functions": "^0.12.7",
     "connect-static-file": "^2.0.0",
     "cors": "^2.8.5",
+    "draco3dgltf": "^1.5.2",
     "express": "^4.17.1",
     "https": "^1.0.0",
     "selfsigned": "^1.10.8",

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,6 +20,10 @@ program
     "-w, --watch",
     "Watch the input file for changes and continously re-optimize it. Also send out a message on the local websocket when used with --serve"
   )
+  .option(
+    "-d, --draco",
+    "Compress with Draco compression"
+  )
   .action(optimizeCmd);
 
 // Placeholder for any async init we may need later


### PR DESCRIPTION
Adds really basic support for Draco mesh compression, it uses the default options and just exposes Draco compression as a toggle.  This is done so that Draco mesh compression can be combined with ktx basisu texture compression as there is currently no other way to combine the two options for files with Hubs extensions that I know of at present.